### PR TITLE
perf: download receipts/txs in per-block batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "arrayvec",
  "ecdsa",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "async-trait",
  "ethers-core",
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.1.3"
-source = "git+https://github.com/gakonst/ethers-rs#84aafbbd1f657f12cf5bdf4db9c18e70e5ad0754"
+source = "git+https://github.com/gakonst/ethers-rs#d2d7a82a8027d96a2ce6449b27477d37d5beaddf"
 dependencies = [
  "async-trait",
  "elliptic-curve",


### PR DESCRIPTION
Instead of getting the gas used and the gas price by doing 2 RPC requests per tx, we can just fetch all txs/receipts in a block in 2 RPC calls.