### PR TITLE
Add inserted_at field to DB table

### DIFF
--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -59,7 +59,9 @@ impl<'a> MevDB<'a> {
 
                     eoa text,
                     contract text,
-                    proxy_impl text
+                    proxy_impl text,
+
+                    inserted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
                 )",
                 self.table_name
             ))


### PR DESCRIPTION
It defaults to `now()`, so we don't need to explicitly fill it in
