### PR TITLE
test: update failing tests

### DIFF
--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -115,28 +115,28 @@ pub static FILTER: Lazy<HashSet<Address>> = Lazy::new(|| {
     set.insert(parse_address("0x9509665d015bfe3c77aa5ad6ca20c8afa1d98989"));
     // paraswap v2
     set.insert(parse_address("0x86969d29F5fd327E1009bA66072BE22DB6017cC6"));
-     // Paraswap v3
-    set.insert(parse_address("0xf90e98f3d8dce44632e5020abf2e122e0f99dfab"));    
+    // Paraswap v3
+    set.insert(parse_address("0xf90e98f3d8dce44632e5020abf2e122e0f99dfab"));
     // furucombo
     set.insert(parse_address("0x57805e5a227937bac2b0fdacaa30413ddac6b8e1"));
     // furucombo proxy v1
-    set.insert(parse_address("0x17e8ca1b4798b97602895f63206afcd1fc90ca5f"));  
+    set.insert(parse_address("0x17e8ca1b4798b97602895f63206afcd1fc90ca5f"));
     // yearn recycler
     set.insert(parse_address("0x5F07257145fDd889c6E318F99828E68A449A5c7A"));
     // drc, weird deflationary token
     set.insert(parse_address("0xc66d62a2f9ff853d9721ec94fa17d469b40dde8d"));
     // Rootkit finance deployer
     set.insert(parse_address("0x804cc8d469483d202c69752ce0304f71ae14abdf"));
-     // Metamask Swap
+    // Metamask Swap
     set.insert(parse_address("0x881d40237659c251811cec9c364ef91dc08d300c"));
     // DEX.ag
     set.insert(parse_address("0x745daa146934b27e3f0b6bff1a6e36b9b90fb131"));
-     // Cream Finance deployer
+    // Cream Finance deployer
     set.insert(parse_address("0x197939c1ca20c2b506d6811d8b6cdb3394471074"));
-     // Zerion SDK
-    set.insert(parse_address("0xb2be281e8b11b47fec825973fc8bb95332022a54"));  
-     // KeeperDAO
-    set.insert(parse_address("0x3d71d79c224998e608d03c5ec9b405e7a38505f0")); 
+    // Zerion SDK
+    set.insert(parse_address("0xb2be281e8b11b47fec825973fc8bb95332022a54"));
+    // KeeperDAO
+    set.insert(parse_address("0x3d71d79c224998e608d03c5ec9b405e7a38505f0"));
     set
 });
 

--- a/src/inspectors/balancer.rs
+++ b/src/inspectors/balancer.rs
@@ -154,7 +154,7 @@ mod tests {
         bal.inspect(&mut inspection);
 
         let known = inspection.known();
-        dbg!(&known);
+
         assert_eq!(known.len(), 4);
         let t1 = known[0].as_ref().transfer().unwrap();
         assert_eq!(
@@ -177,7 +177,7 @@ mod tests {
         bal.inspect(&mut inspection);
 
         let known = inspection.known();
-        dbg!(&known);
+
         assert_eq!(known.len(), 3);
         let trade = known[0].as_ref().trade().unwrap();
         assert_eq!(

--- a/src/inspectors/batch.rs
+++ b/src/inspectors/batch.rs
@@ -109,8 +109,6 @@ mod tests {
 
         let known = inspection.known();
 
-        dbg!(&known);
-
         let liquidation = known
             .iter()
             .find_map(|action| action.as_ref().profitable_liquidation())
@@ -263,7 +261,7 @@ mod tests {
         inspection.prune();
 
         let known = inspection.known();
-        dbg!(&known);
+
         assert_eq!(inspection.status, Status::Reverted);
         assert_eq!(inspection.protocols, set![Protocol::Uniswap])
     }

--- a/src/inspectors/curve.rs
+++ b/src/inspectors/curve.rs
@@ -155,7 +155,7 @@ mod tests {
                 .unwrap();
         let curve = Curve::create(std::sync::Arc::new(provider)).await.unwrap();
 
-        assert_eq!(curve.pools.len(), 30);
+        assert!(!curve.pools.is_empty());
     }
 
     struct MyInspector {

--- a/src/inspectors/uniswap.rs
+++ b/src/inspectors/uniswap.rs
@@ -279,7 +279,7 @@ pub mod tests {
             uni.inspect(&mut inspection);
 
             let known = inspection.known();
-            dbg!(&known);
+
             assert!(known[0].as_ref().deposit().is_some());
             let arb = known[1].as_ref().arbitrage().unwrap();
             assert_eq!(arb.profit, U256::from_dec_str("23939671034095067").unwrap());
@@ -296,7 +296,7 @@ pub mod tests {
             uni.inspect(&mut inspection);
 
             let known = inspection.known();
-            dbg!(&known);
+
             let arb = known[0].as_ref().arbitrage().unwrap();
             assert_eq!(arb.profit, U256::from_dec_str("9196963592118237").unwrap());
 
@@ -379,7 +379,7 @@ pub mod tests {
         uni.inspect(&mut inspection);
 
         let known = inspection.known();
-        dbg!(&known);
+
         assert_eq!(known.len(), 4);
         let t1 = known[0].as_ref().transfer().unwrap();
         assert_eq!(
@@ -449,7 +449,6 @@ pub mod tests {
             assert_eq!(inspection.known().len(), 3);
             assert_eq!(inspection.unknown().len(), 2);
 
-            dbg!(&known);
             let withdrawal = known[1].as_ref().withdrawal();
             assert!(withdrawal.is_some());
 

--- a/src/inspectors/zeroex.rs
+++ b/src/inspectors/zeroex.rs
@@ -124,7 +124,6 @@ mod tests {
         );
         assert_eq!(inspection.status, Status::Reverted);
         let known = inspection.known();
-        dbg!(&known);
 
         assert_eq!(known.len(), 3);
         // transfer in

--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -180,18 +180,22 @@ mod tests {
     use ethers::types::{Address, TxHash};
     use std::collections::HashSet;
 
+    /// This expects postgres running on localhost:5432 with user `mev_rs_user` and table `mev_inspections_test`
     #[tokio::test]
     async fn insert_eval() {
-        let mut client = MevDB::connect("localhost", "postgres", None, "test_table")
-            .await
-            .unwrap();
-        client.clear().await.unwrap();
+        let mut config = Config::default();
+        config
+            .host("localhost")
+            .user("mev_rs_user")
+            .dbname("mev_inspections_test");
+        let mut client = MevDB::connect(config, "mev_inspections").await.unwrap();
+        let _ = client.clear().await;
         client.create().await.unwrap();
 
         let inspection = Inspection {
             status: crate::types::Status::Checked,
             actions: Vec::new(),
-            protocols: Vec::new(),
+            protocols: HashSet::new(),
             from: Address::zero(),
             contract: Address::zero(),
             proxy_impl: None,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

## Motivation
This fixes the not compiling `tokio` tests and the failing `curve` test
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* only require the returned pools in `curve::test::instantiate` to be not empty because the real pool size may fluctuate
* make the not compiling tokio test compile again and succeed, **if postgres is running at localhost:5432 and user `mev_rs_user` exist and was granted access to the `mev_inspections_test` database**.  Not sure if it's worth integrating this into the CI.
* drop all the `dbg!(&known)` statements in the inspectors tests
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
