### PR TITLE
Make multi block processing parallizeable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "auto_impl"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +346,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -881,6 +905,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1137,9 @@ dependencies = [
  "gumdrop",
  "hex",
  "itertools",
+ "log",
  "once_cell",
+ "pretty_env_logger",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -1405,6 +1440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1506,12 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1963,6 +2014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2459,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rust_decimal = { version = "1.10.0", features = ["db-postgres", "db-tokio-postgr
 gumdrop = "0.8.0"
 futures = "0.3.8"
 hex = "0.4.2"
+log = "0.4.14"
+pretty_env_logger = "0.4.0"
 
 [features]
 postgres-tests = []

--- a/src/inspectors/batch.rs
+++ b/src/inspectors/batch.rs
@@ -120,9 +120,7 @@ async fn get_block_info<M: Middleware + Unpin + 'static>(
             error,
         })
         .and_then(|block| {
-            futures::future::ready(
-                block.ok_or_else(|| BatchEvaluationError::NotFound(block_number)),
-            )
+            futures::future::ready(block.ok_or(BatchEvaluationError::NotFound(block_number)))
         });
 
     let receipts = provider
@@ -197,7 +195,7 @@ impl<M: Middleware + Unpin + 'static> BatchEvaluator<M> {
 
     fn queue_in_evaluation(&mut self, inspection: Inspection, gas_used: U256, gas_price: U256) {
         let block_number = inspection.block_number;
-        let hash = inspection.hash.clone();
+        let hash = inspection.hash;
         let prices = Arc::clone(&self.prices);
         let eval = Box::pin(async move {
             Evaluation::new(inspection, prices.as_ref(), gas_used, gas_price)

--- a/src/inspectors/mod.rs
+++ b/src/inspectors/mod.rs
@@ -26,7 +26,7 @@ pub use erc20::ERC20;
 
 mod batch;
 /// Takes multiple inspectors
-pub use batch::BatchInspector;
+pub use batch::{BatchEvaluationError, BatchInspector};
 
 mod compound;
 pub use compound::Compound;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use traits::*;
 
 /// PostGres trait implementations
 mod mevdb;
-pub use mevdb::MevDB;
+pub use mevdb::{BatchInserts, MevDB};
 
 mod prices;
 pub use prices::HistoricalPrice;

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ async fn process_block<M: Middleware + 'static>(
     block_number: u64,
     provider: &M,
     processor: &BatchInspector,
-    db: &mut MevDB<'_>,
+    db: &mut MevDB,
     prices: &HistoricalPrice<M>,
 ) -> anyhow::Result<()> {
     let block_number = block_number.into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,8 @@ async fn run<M: Middleware + Clone + 'static>(provider: M, opts: Opts) -> anyhow
                         let _ = tx.send_all(&mut iter).await;
                     });
                 }
+                // drop the sender so that the channel gets closed
+                drop(tx);
 
                 // all the evaluations arrive at the receiver and are inserted into the DB
                 let mut inserts = BatchInserts::new(db, recv);

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,11 @@ struct BlockOpts {
     to: u64,
     #[options(default = "4", help = "How many separate tasks to use")]
     tasks: u64,
+    #[options(
+        default = "10",
+        help = "Maximum of requests each task is allowed to execute concurrently"
+    )]
+    max_requests: usize,
 }
 
 #[tokio::main]
@@ -173,7 +178,7 @@ async fn run<M: Middleware + Clone + 'static>(provider: M, opts: Opts) -> anyhow
                         Arc::clone(&provider),
                         Arc::clone(&prices),
                         rem_start..inner.to,
-                        10,
+                        inner.max_requests,
                     );
                     let mut tx = tx.clone();
                     log::debug!("spawning batch for blocks: [{}..{})", rem_start, inner.to);
@@ -196,7 +201,7 @@ async fn run<M: Middleware + Clone + 'static>(provider: M, opts: Opts) -> anyhow
                         Arc::clone(&provider),
                         Arc::clone(&prices),
                         from..from + blocks_per_task,
-                        10,
+                        inner.max_requests,
                     );
                     let mut tx = tx.clone();
                     log::debug!(

--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -5,15 +5,15 @@ use thiserror::Error;
 use tokio_postgres::{config::Config, Client, NoTls};
 
 /// Wrapper around PostGres for storing results in the database
-pub struct MevDB<'a> {
+pub struct MevDB {
     client: Client,
-    table_name: &'a str,
+    table_name: String,
     overwrite: String,
 }
 
-impl<'a> MevDB<'a> {
+impl MevDB {
     /// Connects to the MEV PostGres instance
-    pub async fn connect(cfg: Config, table_name: &'a str) -> Result<MevDB<'a>, DbError> {
+    pub async fn connect(cfg: Config, table_name: impl Into<String>) -> Result<Self, DbError> {
         let (client, connection) = cfg.connect(NoTls).await?;
 
         tokio::spawn(async move {
@@ -26,7 +26,7 @@ impl<'a> MevDB<'a> {
         let overwrite = "on conflict do nothing";
         Ok(Self {
             client,
-            table_name,
+            table_name: table_name.into(),
             overwrite: overwrite.to_owned(),
         })
     }

--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -173,7 +173,7 @@ type EvaluationStream<'a, M> =
     Pin<Box<dyn Stream<Item = Result<Evaluation, BatchEvaluationError<M>>> + 'a>>;
 
 /// Takes a stream of `Evaluation`s and puts it in the database
-pub struct BatchInserter<'a, M: Middleware + Unpin + 'static> {
+pub struct BatchInserts<'a, M: Middleware + Unpin + 'static> {
     mev_db: Option<MevDB>,
     /// The currently running insert job
     insertion: Option<EvalInsertion>,
@@ -185,7 +185,7 @@ pub struct BatchInserter<'a, M: Middleware + Unpin + 'static> {
     evals_done: bool,
 }
 
-impl<'a, M: Middleware + Unpin + 'static> BatchInserter<'a, M> {
+impl<'a, M: Middleware + Unpin + 'static> BatchInserts<'a, M> {
     pub fn new<S>(mev_db: MevDB, evals: S) -> Self
     where
         S: Stream<Item = Result<Evaluation, BatchEvaluationError<M>>> + 'a,
@@ -214,7 +214,7 @@ impl<'a, M: Middleware + Unpin + 'static> BatchInserter<'a, M> {
     }
 }
 
-impl<'a, M: Middleware + Unpin> Stream for BatchInserter<'a, M> {
+impl<'a, M: Middleware + Unpin> Stream for BatchInserts<'a, M> {
     type Item = Result<Evaluation, InsertEvaluationError<M>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -276,6 +276,7 @@ impl<'a, M: Middleware + Unpin> Stream for BatchInserts<'a, M> {
 
         // If more evaluations and insertions are processed we're not done yet
         if this.evals_done && this.insertion_queue.is_empty() && this.insertion.is_none() {
+            log::trace!("batch insert done");
             Poll::Ready(None)
         } else {
             Poll::Pending
@@ -294,8 +295,14 @@ async fn insert_evaluation(
     mut db: MevDB,
 ) -> Result<(Evaluation, MevDB), (MevDB, DbError)> {
     if let Err(err) = db.insert(&eval).await {
+        log::error!("DB insert failed: {:?}", err);
         Err((db, err))
     } else {
+        log::debug!(
+            "inserted evaluation of block {} with tx {}",
+            eval.inspection.block_number,
+            eval.inspection.hash
+        );
         Ok((eval, db))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

## Motivation
This attempts to fix #24 by adding support for spawning the processing of blocks
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Introduced new `Stream` types:
* `BatchEvaluator`: a `Stream: Send+Sync` that processes multiple blocks and their inspections and yields the `Evaluation`
    *  The `dyn Inspector`s and `dyn Reducer`s are therefor also required to be `Send + Sync`
* `BatchInserts`: takes a `Stream` of `Evaluations` and puts them in the DB

The `BatchEvaluator` can be spawned to a new task, a new `task` option in the `BlockOpts` allows to control how many `BatchEvaluator`s should be spawned, the range of blocks is then divided equally to the `BatchEvaluator`s which all pipe their `Evaluation`s via channels to the `BatchInserts`. Right now a single `MevDB` handle is used, but it would be possible to add more.

Since I don't have access to an archive node, I wasn't able to test that yet. Any Tips on how I can test this would be appreciated 🙃

two more `batch` subcommand options are added:
* `tasks`: how many task should be used for fetching all the info
* `max-requests`: how many requests each task is allowed to execute concurrently



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
