### PR TITLE
FIX flashbots documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <h1 align="center"> MEV Inspect </h1>
 
 **Ethereum MEV Inspector in Rust**
-</br> Further documentation on mev-inspect-rs available [here](https://docs.flashbots.net/flashbots-data/mev-inspect-rs/inspect-quick-start)
+</br> Further documentation on mev-inspect-rs available [here](https://docs.flashbots.net/flashbots-data/deprecated/mev-inspect-rs/inspect-quick-start)
 
 ## Inspectors
 


### PR DESCRIPTION
## Motivation

The link was broken, so I updated the reference.
NOTE: The referenced Flashbots documentation is deprecated


